### PR TITLE
Install required libs to `lib` folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,9 +114,11 @@ set(RECASTNAVIGATION_DEMO OFF CACHE BOOL "Build demo")
 set(RECASTNAVIGATION_TESTS OFF CACHE BOOL "Build tests")
 set(RECASTNAVIGATION_EXAMPLES OFF CACHE BOOL "Build examples")
 add_subdirectory(recastnavigation EXCLUDE_FROM_ALL)
+install(TARGETS Detour Recast ARCHIVE DESTINATION lib)
 
 add_definitions(-DSTORMLIB_NO_AUTO_LINK)
 add_subdirectory(stormlib EXCLUDE_FROM_ALL)
+install(TARGETS storm ARCHIVE DESTINATION lib)
 
 # namigator libraries
 add_subdirectory(utility)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,24 +30,28 @@ if(DEFINED ENV{pythonLocation})
     set(Python3_FIND_REGISTRY NEVER)
 endif()
 
-# First try finding python 3 development files
-find_package(Python3 COMPONENTS Development)
+option(NAMIGATOR_BUILD_PYTHON "Build Python bindings if Python2/3 is present." TRUE)
 
-if (Python3_FOUND)
-    set(PYTHON_COMPONENT "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
-    set(PYTHON_LIBRARIES "${Python3_LIBRARIES}")
-    set(PYTHON_INCLUDE_DIRS "${Python3_INCLUDE_DIRS}")
-else()
-    message(STATUS "Could not find python3.  Attemping to find python2.")
-    find_package(Python2 COMPONENTS Development)
-    if (Python2_FOUND)
-        set(PYTHON_COMPONENT "python${Python2_VERSION_MAJOR}${Python2_VERSION_MINOR}")
-        set(PYTHON_LIBRARIES "${Python2_LIBRARIES}")
-        set(PYTHON_INCLUDE_DIRS "${Python2_INCLUDE_DIRS}")
+if(NAMIGATOR_BUILD_PYTHON)
+    # First try finding python 3 development files
+    find_package(Python3 COMPONENTS Development)
+
+    if (Python3_FOUND)
+        set(PYTHON_COMPONENT "python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}")
+        set(PYTHON_LIBRARIES "${Python3_LIBRARIES}")
+        set(PYTHON_INCLUDE_DIRS "${Python3_INCLUDE_DIRS}")
     else()
-        message(STATUS "Could not find python2 either.")
+        message(STATUS "Could not find python3.  Attemping to find python2.")
+        find_package(Python2 COMPONENTS Development)
+        if (Python2_FOUND)
+            set(PYTHON_COMPONENT "python${Python2_VERSION_MAJOR}${Python2_VERSION_MINOR}")
+            set(PYTHON_LIBRARIES "${Python2_LIBRARIES}")
+            set(PYTHON_INCLUDE_DIRS "${Python2_INCLUDE_DIRS}")
+        else()
+            message(STATUS "Could not find python2 either.")
+        endif()
     endif()
-endif()
+endif() # NAMIGATOR_BUILD_PYTHON
 
 # Enable debug output from FindBoost
 #set(Boost_DEBUG ON)
@@ -95,7 +99,7 @@ if (PYTHON_COMPONENT)
     endif()
 endif()
 
-if (NOT PYTHON_COMPONENT)
+if (NAMIGATOR_BUILD_PYTHON AND NOT PYTHON_COMPONENT)
     message(WARNING "No boost-compatible python was found.  Python bindings for ${CMAKE_PROJECT_NAME} will not be compiled")
 endif()
 

--- a/MapViewer/CMakeLists.txt
+++ b/MapViewer/CMakeLists.txt
@@ -29,6 +29,6 @@ set_source_files_properties(VertexShader.hlsl PROPERTIES
 
 add_executable(${EXECUTABLE_NAME} WIN32 ${SHADERS} ${SRC})
 
-target_link_libraries(${EXECUTABLE_NAME} PRIVATE utility parser libpathfind storm RecastNavigation::Detour RecastNavigation::DebugUtils)
+target_link_libraries(${EXECUTABLE_NAME} PRIVATE utility parser pathfind storm RecastNavigation::Detour RecastNavigation::DebugUtils)
 
 install(TARGETS ${EXECUTABLE_NAME} DESTINATION bin)

--- a/MapViewer/CMakeLists.txt
+++ b/MapViewer/CMakeLists.txt
@@ -29,6 +29,6 @@ set_source_files_properties(VertexShader.hlsl PROPERTIES
 
 add_executable(${EXECUTABLE_NAME} WIN32 ${SHADERS} ${SRC})
 
-target_link_libraries(${EXECUTABLE_NAME} PRIVATE utility parser pathfind storm RecastNavigation::Detour RecastNavigation::DebugUtils)
+target_link_libraries(${EXECUTABLE_NAME} PRIVATE utility parser libpathfind storm RecastNavigation::Detour RecastNavigation::DebugUtils)
 
 install(TARGETS ${EXECUTABLE_NAME} DESTINATION bin)

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -31,3 +31,5 @@ add_library(parser STATIC ${SRC_MAP} ${SRC_ADT} ${SRC_WMO} ${SRC_DOODAD}
 
 target_link_libraries(parser utility storm ${FILESYSTEM_LIBRARY})
 target_include_directories(parser PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+install(TARGETS parser ARCHIVE DESTINATION lib)

--- a/pathfind/CMakeLists.txt
+++ b/pathfind/CMakeLists.txt
@@ -7,11 +7,11 @@ set(SRC
     Tile.cpp
 )
 
-add_library(lib${LIBRARY_NAME} STATIC ${SRC})
-target_include_directories(lib${LIBRARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(lib${LIBRARY_NAME} PRIVATE ${FILESYSTEM_LIBRARY} utility RecastNavigation::Recast RecastNavigation::Detour)
+add_library(${LIBRARY_NAME} STATIC ${SRC})
+target_include_directories(${LIBRARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(${LIBRARY_NAME} PRIVATE ${FILESYSTEM_LIBRARY} utility RecastNavigation::Recast RecastNavigation::Detour)
 
-install(TARGETS lib${LIBRARY_NAME} ARCHIVE DESTINATION lib)
+install(TARGETS ${LIBRARY_NAME} ARCHIVE DESTINATION lib)
 
 if (PYTHON_COMPONENT)
     if (Python3_FOUND)

--- a/pathfind/CMakeLists.txt
+++ b/pathfind/CMakeLists.txt
@@ -7,11 +7,11 @@ set(SRC
     Tile.cpp
 )
 
-add_library(${LIBRARY_NAME} STATIC ${SRC})
-target_include_directories(${LIBRARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
-target_link_libraries(${LIBRARY_NAME} PRIVATE ${FILESYSTEM_LIBRARY} utility RecastNavigation::Recast RecastNavigation::Detour)
+add_library(lib${LIBRARY_NAME} STATIC ${SRC})
+target_include_directories(lib${LIBRARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(lib${LIBRARY_NAME} PRIVATE ${FILESYSTEM_LIBRARY} utility RecastNavigation::Recast RecastNavigation::Detour)
 
-install(TARGETS ${LIBRARY_NAME} ARCHIVE DESTINATION lib)
+install(TARGETS lib${LIBRARY_NAME} ARCHIVE DESTINATION lib)
 
 if (PYTHON_COMPONENT)
     if (Python3_FOUND)

--- a/pathfind/CMakeLists.txt
+++ b/pathfind/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(lib${LIBRARY_NAME} STATIC ${SRC})
 target_include_directories(lib${LIBRARY_NAME} PRIVATE ${CMAKE_SOURCE_DIR})
 target_link_libraries(lib${LIBRARY_NAME} PRIVATE ${FILESYSTEM_LIBRARY} utility RecastNavigation::Recast RecastNavigation::Detour)
 
+install(TARGETS lib${LIBRARY_NAME} ARCHIVE DESTINATION lib)
+
 if (PYTHON_COMPONENT)
     if (Python3_FOUND)
         Python3_add_library(${LIBRARY_NAME} ${SRC} python.cpp)

--- a/utility/BoundingBox.cpp
+++ b/utility/BoundingBox.cpp
@@ -1,6 +1,7 @@
 #include "utility/BoundingBox.hpp"
 
 #include <algorithm>
+#include <limits>
 
 namespace math
 {

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -11,3 +11,5 @@ add_library(utility STATIC
 )
 
 target_include_directories(utility PUBLIC ..)
+
+install(TARGETS utility ARCHIVE DESTINATION lib)


### PR DESCRIPTION
Hi, awesome effort. 

I'm currently writing Rust bindings for this lib and I want to statically link it in order to prevent shared library nonsense. In order to do this I need to link with all the archives. These can be found in various subfolders of the build directory, but it's significantly simpler to just have them all in the `${BUILD_DIR}/lib` folder.

In order to write the bindings I will also need to write a C API wrapper much like the [Python bindings for pathfind](https://github.com/namreeb/namigator/blob/9cd3a7a9cafe6b726f8b2cc7f7f1cf6797601a9a/pathfind/python.cpp#L14) and [mapbuilder](https://github.com/namreeb/namigator/blob/master/MapBuilder/python.cpp#L15). I intend on upstreaming them to this repo so that people who are creating bindings for other languages can also benefit from them. I'm probably just going to put them inside `c_bindings.cpp/.hpp` files in `pathfind` and `mapbuild`, is this OK with you? 