### PR TITLE
Make C API pointers const and add line_of_sight to C API

### DIFF
--- a/MapBuilder/MapBuilder_c_bindings.cpp
+++ b/MapBuilder/MapBuilder_c_bindings.cpp
@@ -11,7 +11,7 @@ extern "C" {
 MapBuildResultType mapbuild_build_bvh(const char* const data_path,
                              const char* const output_path,
                              uint32_t threads,
-                             uint32_t* amount_of_bvhs_built)
+                             uint32_t* const amount_of_bvhs_built)
 {
     std::string outputPath = output_path;
 

--- a/MapBuilder/mapbuilder_c_bindings.h
+++ b/MapBuilder/mapbuilder_c_bindings.h
@@ -8,7 +8,7 @@ typedef uint8_t MapBuildResultType;
 MapBuildResultType mapbuild_build_bvh(const char* const data_path,
                                       const char* const output_path,
                                       uint32_t threads,
-                                      uint32_t* amount_of_bvhs_built);
+                                      uint32_t* const amount_of_bvhs_built);
 
 MapBuildResultType mapbuild_build_map(const char* const data_path,
                                       const char* const output_path,

--- a/pathfind/pathfind_c_bindings.cpp
+++ b/pathfind/pathfind_c_bindings.cpp
@@ -228,4 +228,28 @@ PathfindResultType pathfind_find_height(pathfind::Map* const map, float start_x,
         return static_cast<PathfindResultType>(Result::UNKNOWN_EXCEPTION);
     }
 }
+
+PathfindResultType pathfind_line_of_sight(pathfind::Map* map,
+                                          float start_x, float start_y, float start_z,
+                                          float stop_x, float stop_y, float stop_z,
+                                          uint8_t* const line_of_sight) {
+    try
+    {
+        if (map->LineOfSight({start_x, start_y, start_z}, {stop_x, stop_y, stop_z})) {
+            *line_of_sight = 1;
+        } else {
+            *line_of_sight = 0;
+        }
+
+        return static_cast<PathfindResultType>(Result::SUCCESS);
+    }
+    catch (utility::exception& e)
+    {
+        return static_cast<PathfindResultType>(e.ResultCode());
+    }
+    catch (...)
+    {
+        return static_cast<PathfindResultType>(Result::UNKNOWN_EXCEPTION);
+    }
+}
 } // extern "C"

--- a/pathfind/pathfind_c_bindings.cpp
+++ b/pathfind/pathfind_c_bindings.cpp
@@ -23,11 +23,11 @@ pathfind::Map* pathfind_new_map(const char* const data_path, const char* const m
     }
 }
 
-void pathfind_free_map(pathfind::Map* map) {
+void pathfind_free_map(pathfind::Map* const map) {
     delete map;
 }
 
-PathfindResultType pathfind_load_all_adts(pathfind::Map* map, int32_t* amount_of_adts_loaded) {
+PathfindResultType pathfind_load_all_adts(pathfind::Map* const map, int32_t* const amount_of_adts_loaded) {
     try {
         *amount_of_adts_loaded = map->LoadAllADTs();
         return static_cast<PathfindResultType>(Result::SUCCESS);
@@ -40,7 +40,7 @@ PathfindResultType pathfind_load_all_adts(pathfind::Map* map, int32_t* amount_of
     }
 }
 
-PathfindResultType pathfind_load_adt(pathfind::Map* map, int adt_x, int adt_y, float* out_adt_x, float* out_adt_y) {
+PathfindResultType pathfind_load_adt(pathfind::Map* const map, int adt_x, int adt_y, float* const out_adt_x, float* const out_adt_y) {
     try {
         if (!map->HasADT(adt_x, adt_y)) {
             return static_cast<PathfindResultType>(Result::MAP_DOES_NOT_HAVE_ADT);
@@ -63,7 +63,7 @@ PathfindResultType pathfind_load_adt(pathfind::Map* map, int adt_x, int adt_y, f
     }
 }
 
-PathfindResultType pathfind_load_adt_at(pathfind::Map* map, float x, float y, float* out_adt_x, float* out_adt_y) {
+PathfindResultType pathfind_load_adt_at(pathfind::Map* const map, float x, float y, float* const out_adt_x, float* const out_adt_y) {
     try {
         int adt_y = 0;
         int adt_x = 0;
@@ -91,12 +91,12 @@ PathfindResultType pathfind_load_adt_at(pathfind::Map* map, float x, float y, fl
     }
 }
 
-PathfindResultType pathfind_get_zone_and_area(pathfind::Map* map,
+PathfindResultType pathfind_get_zone_and_area(pathfind::Map* const map,
                        float x,
                        float y,
                        float z,
-                       unsigned int* out_zone,
-                       unsigned int* out_area)
+                       unsigned int* const out_zone,
+                       unsigned int* const out_area)
 {
     unsigned int zone = -1;
     unsigned int area = -1;
@@ -122,16 +122,16 @@ PathfindResultType pathfind_get_zone_and_area(pathfind::Map* map,
     }
 }
 
-PathfindResultType pathfind_find_path(pathfind::Map* map,
+PathfindResultType pathfind_find_path(pathfind::Map* const map,
                float start_x,
                float start_y,
                float start_z,
                float stop_x,
                float stop_y,
                float stop_z,
-               Vertex* buffer,
+               Vertex* const buffer,
                unsigned int buffer_length,
-               unsigned int* amount_of_vertices)
+               unsigned int* const amount_of_vertices)
 {
     const math::Vertex start {start_x, start_y, start_z};
     const math::Vertex stop {stop_x, stop_y, stop_z};
@@ -168,12 +168,12 @@ PathfindResultType pathfind_find_path(pathfind::Map* map,
     }
 }
 
-PathfindResultType pathfind_find_heights(pathfind::Map* map,
+PathfindResultType pathfind_find_heights(pathfind::Map* const map,
                   float x,
                   float y,
-                  float* buffer,
+                  float* const buffer,
                   unsigned int buffer_length,
-                  unsigned int* amount_of_heights)
+                  unsigned int* const amount_of_heights)
 {
     std::vector<float> height_values;
 
@@ -202,10 +202,10 @@ PathfindResultType pathfind_find_heights(pathfind::Map* map,
     }
 }
 
-PathfindResultType pathfind_find_height(pathfind::Map* map, float start_x,
+PathfindResultType pathfind_find_height(pathfind::Map* const map, float start_x,
     float start_y, float start_z,
     float stop_x, float stop_y,
-    float* stop_z)
+    float* const stop_z)
 {
     try
     {

--- a/pathfind/pathfind_c_bindings.hpp
+++ b/pathfind/pathfind_c_bindings.hpp
@@ -17,37 +17,37 @@ pathfind::Map* pathfind_new_map(const char* const data_path,
                                 const char* const map_name,
                                 PathfindResultTypePtr result);
 
-void pathfind_free_map(pathfind::Map* map);
+void pathfind_free_map(pathfind::Map* const map);
 
-PathfindResultType pathfind_load_all_adts(pathfind::Map* map,
-                                          int32_t* amount_of_adts_loaded);
+PathfindResultType pathfind_load_all_adts(pathfind::Map* const map,
+                                          int32_t* const amount_of_adts_loaded);
 
-PathfindResultType pathfind_load_adt(pathfind::Map* map, int adt_x, int adt_y,
-                                     float* out_adt_x, float* out_adt_y);
+PathfindResultType pathfind_load_adt(pathfind::Map* const map, int adt_x, int adt_y,
+                                     float* const out_adt_x, float* const out_adt_y);
 
-PathfindResultType pathfind_load_adt_at(pathfind::Map* map, float x, float y,
-                                        float* out_adt_x, float* out_adt_y);
+PathfindResultType pathfind_load_adt_at(pathfind::Map* const map, float x, float y,
+                                        float* const out_adt_x, float* const out_adt_y);
 
-PathfindResultType pathfind_get_zone_and_area(pathfind::Map* map, float x,
+PathfindResultType pathfind_get_zone_and_area(pathfind::Map* const map, float x,
                                               float y, float z,
-                                              unsigned int* out_zone,
-                                              unsigned int* out_area);
+                                              unsigned int* const out_zone,
+                                              unsigned int* const out_area);
 
-PathfindResultType pathfind_find_path(pathfind::Map* map, float start_x,
+PathfindResultType pathfind_find_path(pathfind::Map* const map, float start_x,
                                       float start_y, float start_z,
                                       float stop_x, float stop_y, float stop_z,
-                                      Vertex* buffer,
+                                      Vertex* const buffer,
                                       unsigned int buffer_length,
-                                      unsigned int* amount_of_vertices);
+                                      unsigned int* const amount_of_vertices);
 
-PathfindResultType pathfind_find_heights(pathfind::Map* map, float x, float y,
-                                         float* buffer,
+PathfindResultType pathfind_find_heights(pathfind::Map* const map, float x, float y,
+                                         float* const buffer,
                                          unsigned int buffer_length,
-                                         unsigned int* amount_of_heights);
+                                         unsigned int* const amount_of_heights);
 
-PathfindResultType pathfind_find_height(pathfind::Map* map, float start_x,
+PathfindResultType pathfind_find_height(pathfind::Map* const map, float start_x,
                                         float start_y, float start_z,
                                         float stop_x, float stop_y,
-                                        float* stop_z);
+                                        float* const stop_z);
 } // extern "C"
 

--- a/pathfind/pathfind_c_bindings.hpp
+++ b/pathfind/pathfind_c_bindings.hpp
@@ -49,5 +49,10 @@ PathfindResultType pathfind_find_height(pathfind::Map* const map, float start_x,
                                         float start_y, float start_z,
                                         float stop_x, float stop_y,
                                         float* const stop_z);
+
+PathfindResultType pathfind_line_of_sight(pathfind::Map* const map,
+                                          float start_x, float start_y, float start_z,
+                                          float stop_x, float stop_y, float stop_z,
+                                          uint8_t* const line_of_sight);
 } // extern "C"
 


### PR DESCRIPTION
Hey,
Got a few small changes. I'm also hoping to get working more on [namigator-rs](https://github.com/gtker/namigator-rs), so I'll probably be opening some issues as well.

___

This ensures that the underlying object can still be mutated but the pointer location can not.

This just ensures that calling functions don't have to be overly defensive about what is happening with pointers passed to the API.
For example the Map pointer can't be changed to a nullptr, or to another Map object.