### PR TITLE
Add argument names and docstrings for Python files + Fix nested filesystem folders

### DIFF
--- a/MapBuilder/FileExist.cpp
+++ b/MapBuilder/FileExist.cpp
@@ -19,24 +19,15 @@ bool map_files_exist(const std::string& outputPath, const std::string& mapName) 
 namespace files {
 
 void create_bvh_output_directory(const std::filesystem::path& outputPath) {
-    if (!fs::is_directory(outputPath)) {
-        fs::create_directory(outputPath);
-    }
-
-    if (!fs::is_directory(outputPath / "BVH")) {
-        fs::create_directory(outputPath / "BVH");
-    }
+    fs::create_directories(outputPath / "BVH");
 }
 
 void create_nav_output_directory(const std::filesystem::path& outputPath) {
-    if (!fs::is_directory(outputPath / "Nav")) {
-        fs::create_directory(outputPath / "Nav");
-    }
+    fs::create_directories(outputPath / "Nav");
 }
 
 void create_nav_output_directory_for_map(const std::filesystem::path& outputPath, const std::string& mapName) {
-    if (!fs::is_directory(outputPath / "Nav" / mapName))
-        fs::create_directory(outputPath / "Nav" / mapName);
+    fs::create_directories(outputPath / "Nav" / mapName);
 }
 
 } // namespace files

--- a/MapBuilder/FileExist.cpp
+++ b/MapBuilder/FileExist.cpp
@@ -1,17 +1,42 @@
 #include "FileExist.hpp"
 
-#include <filesystem>
+namespace fs = std::filesystem;
 
 namespace file_exist {
 
 bool bvh_files_exist(const std::string& outputPath) {
     // bvh.idx is created at the very end of building game objects
-    return std::filesystem::exists(outputPath + "/BVH/bvh.idx");
+    return fs::exists(outputPath + "/BVH/bvh.idx");
 }
 
 bool map_files_exist(const std::string& outputPath, const std::string& mapName) {
     // mapName.map is created in MeshBuilder::SaveMap which should be after successful creation
-    return std::filesystem::exists(outputPath + "/" + mapName + ".map");
+    return fs::exists(outputPath + "/" + mapName + ".map");
 }
 
 } // namespace file_exist
+
+namespace files {
+
+void create_bvh_output_directory(const std::filesystem::path& outputPath) {
+    if (!fs::is_directory(outputPath)) {
+        fs::create_directory(outputPath);
+    }
+
+    if (!fs::is_directory(outputPath / "BVH")) {
+        fs::create_directory(outputPath / "BVH");
+    }
+}
+
+void create_nav_output_directory(const std::filesystem::path& outputPath) {
+    if (!fs::is_directory(outputPath / "Nav")) {
+        fs::create_directory(outputPath / "Nav");
+    }
+}
+
+void create_nav_output_directory_for_map(const std::filesystem::path& outputPath, const std::string& mapName) {
+    if (!fs::is_directory(outputPath / "Nav" / mapName))
+        fs::create_directory(outputPath / "Nav" / mapName);
+}
+
+} // namespace files

--- a/MapBuilder/FileExist.hpp
+++ b/MapBuilder/FileExist.hpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <filesystem>
 
 namespace file_exist {
 
@@ -7,3 +8,13 @@ bool bvh_files_exist(const std::string& outputPath);
 bool map_files_exist(const std::string& outputPath, const std::string& mapName);
 
 } // namespace file_exist
+
+namespace files {
+
+void create_bvh_output_directory(const std::filesystem::path& outputPath);
+
+void create_nav_output_directory(const std::filesystem::path& outputPath);
+
+void create_nav_output_directory_for_map(const std::filesystem::path& outputPath, const std::string& mapName);
+
+} // namespace files

--- a/MapBuilder/MapBuilder_c_bindings.cpp
+++ b/MapBuilder/MapBuilder_c_bindings.cpp
@@ -19,11 +19,7 @@ MapBuildResultType mapbuild_build_bvh(const char* const data_path,
     try {
         parser::sMpqManager.Initialize(data_path);
 
-        if (!fs::is_directory(outputPath))
-            fs::create_directory(outputPath);
-
-        if (!fs::is_directory(outputPath + "/BVH"))
-            fs::create_directory(outputPath + "/BVH");
+        files::create_bvh_output_directory(outputPath);
 
         parser::GameObjectBVHBuilder goBuilder(data_path, outputPath, threads);
 
@@ -61,17 +57,9 @@ MapBuildResultType mapbuild_build_map(const char* const data_path,
     try {
         parser::sMpqManager.Initialize(data_path);
 
-        if (!fs::is_directory(outputPath)) {
-            fs::create_directory(outputPath);
-        }
+        files::create_bvh_output_directory(outputPath);
 
-        if (!fs::is_directory(outputPath / "BVH")) {
-            fs::create_directory(outputPath / "BVH");
-        }
-
-        if (!fs::is_directory(outputPath / "Nav")) {
-            fs::create_directory(outputPath / "Nav");
-        }
+        files::create_nav_output_directory(outputPath);
     }
     catch (utility::exception& e) {
         return static_cast<MapBuildResultType >(e.ResultCode());

--- a/MapBuilder/MeshBuilder.cpp
+++ b/MapBuilder/MeshBuilder.cpp
@@ -2,6 +2,7 @@
 
 #include "BVHConstructor.hpp"
 #include "Common.hpp"
+#include "FileExist.hpp"
 #include "RecastContext.hpp"
 #include "parser/Adt/Adt.hpp"
 #include "parser/Adt/AdtChunk.hpp"
@@ -538,8 +539,7 @@ MeshBuilder::MeshBuilder(const std::filesystem::path& outputPath,
 
     m_totalTiles = m_pendingTiles.size();
 
-    if (!fs::is_directory(m_outputPath / "Nav" / mapName))
-        fs::create_directory(m_outputPath / "Nav" / mapName);
+    files::create_nav_output_directory_for_map(m_outputPath, mapName);
 }
 
 MeshBuilder::MeshBuilder(const std::filesystem::path& outputPath,
@@ -569,8 +569,8 @@ MeshBuilder::MeshBuilder(const std::filesystem::path& outputPath,
 
     m_totalTiles = m_pendingTiles.size();
 
-    if (!fs::is_directory(m_outputPath / "Nav" / mapName))
-        fs::create_directory(m_outputPath / "Nav" / mapName);
+
+    files::create_nav_output_directory_for_map(m_outputPath, mapName);
 }
 
 void MeshBuilder::LoadGameObjects(const std::string& path)

--- a/MapBuilder/main.cpp
+++ b/MapBuilder/main.cpp
@@ -5,6 +5,7 @@
 #include "parser/MpqManager.hpp"
 #include "parser/Wmo/WmoInstance.hpp"
 #include "utility/String.hpp"
+#include "FileExist.hpp"
 
 #include <chrono>
 #include <cstdint>
@@ -135,11 +136,7 @@ int main(int argc, char* argv[])
 
     try
     {
-        if (!std::filesystem::is_directory(outputPath))
-            std::filesystem::create_directory(outputPath);
-
-        if (!std::filesystem::is_directory(outputPath + "/BVH"))
-            std::filesystem::create_directory(outputPath + "/BVH");
+        files::create_bvh_output_directory(outputPath);
 
         if (bvh)
         {
@@ -200,8 +197,7 @@ int main(int argc, char* argv[])
             return EXIT_SUCCESS;
         }
 
-        if (!std::filesystem::is_directory(outputPath + "/Nav"))
-            std::filesystem::create_directory(outputPath + "/Nav");
+        files::create_nav_output_directory(outputPath);
 
         // nav mesh generation requires that the MPQ manager be initialized for
         // the main thread, whereas BVH generation above does not.

--- a/MapBuilder/python.cpp
+++ b/MapBuilder/python.cpp
@@ -19,11 +19,7 @@ int BuildBVH(const std::string& dataPath, const std::string& outputPath,
 {
     parser::sMpqManager.Initialize(dataPath);
 
-    if (!fs::is_directory(outputPath))
-        fs::create_directory(outputPath);
-
-    if (!fs::is_directory(outputPath + "/BVH"))
-        fs::create_directory(outputPath + "/BVH");
+    files::create_bvh_output_directory(outputPath);
 
     parser::GameObjectBVHBuilder goBuilder(dataPath, outputPath, workers);
 
@@ -46,14 +42,8 @@ bool BuildMap(const std::string& dataPath, const std::string& outputPath,
 
     parser::sMpqManager.Initialize(dataPath);
 
-    if (!fs::is_directory(outputPath))
-        fs::create_directory(outputPath);
-
-    if (!fs::is_directory(outputPath + "/BVH"))
-        fs::create_directory(outputPath + "/BVH");
-
-    if (!fs::is_directory(outputPath + "/Nav"))
-        fs::create_directory(outputPath + "/Nav");
+    files::create_bvh_output_directory(outputPath);
+    files::create_nav_output_directory(outputPath);
 
     std::unique_ptr<MeshBuilder> builder;
     std::vector<std::unique_ptr<Worker>> workers;
@@ -103,14 +93,8 @@ bool BuildADT(const std::string& dataPath, const std::string& outputPath,
     if (x < 0 || y < 0)
         return false;
 
-    if (!fs::is_directory(outputPath))
-        fs::create_directory(outputPath);
-
-    if (!fs::is_directory(outputPath + "/BVH"))
-        fs::create_directory(outputPath + "/BVH");
-
-    if (!fs::is_directory(outputPath + "/Nav"))
-        fs::create_directory(outputPath + "/Nav");
+    files::create_bvh_output_directory(outputPath);
+    files::create_nav_output_directory(outputPath);
 
     std::unique_ptr<MeshBuilder> builder;
     std::vector<std::unique_ptr<Worker>> workers;

--- a/MapBuilder/python.cpp
+++ b/MapBuilder/python.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 namespace fs = std::filesystem;
+namespace py = pybind11;
 
 int BuildBVH(const std::string& dataPath, const std::string& outputPath,
              size_t workers)
@@ -153,9 +154,41 @@ bool MapFilesExist(const std::string& outputPath, const std::string& mapName) {
 
 PYBIND11_MODULE(mapbuild, m)
 {
-    m.def("build_bvh", &BuildBVH);
-    m.def("build_map", &BuildMap);
-    m.def("build_adt", &BuildADT);
-    m.def("map_files_exist", &MapFilesExist);
-    m.def("bvh_files_exist", &BVHFilesExist);
+    m.def("build_bvh",
+        BuildBVH,
+        "Builds all gameobjects. Must be called before `build_map`.",
+        py::arg("data_path"),
+        py::arg("output_path"),
+        py::arg("workers")
+    );
+    m.def("build_map",
+        &BuildMap,
+        "Builds a specific map. `build_bvh` must be called before this function.",
+        py::arg("data_path"),
+        py::arg("output_path"),
+        py::arg("map_name"),
+        py::arg("threads"),
+        py::arg("go_csv")
+    );
+    m.def("build_adt",
+         &BuildADT,
+         "Build a specific ADT.",
+         py::arg("data_path"),
+         py::arg("output_path"),
+         py::arg("map_name"),
+         py::arg("x"),
+         py::arg("y"),
+         py::arg("go_csv")
+    );
+    m.def("map_files_exist",
+         &MapFilesExist,
+         "Checks if map files exist. If `True` the map will not need to be built.",
+         py::arg("output_path"),
+         py::arg("map_name")
+    );
+    m.def("bvh_files_exist",
+         &BVHFilesExist,
+         "Checks if gameobjects exist. If `True` the gameobjects will not need to be built.",
+         py::arg("output_path")
+    );
 }

--- a/pathfind/python.cpp
+++ b/pathfind/python.cpp
@@ -122,16 +122,96 @@ py::object find_random_point_around_circle(pathfind::Map& map, float x, float y,
 PYBIND11_MODULE(pathfind, m)
 {
     py::class_<pathfind::Map>(m, "Map")
-        .def(py::init<const std::string&, const std::string&>())
-        .def("load_all_adts", &pathfind::Map::LoadAllADTs)
-        .def("load_adt_at", &load_adt_at)
-        .def("load_adt", &load_adt)
-        .def("find_path", &python_find_path)
-        .def("query_heights", &python_query_heights)
-        .def("query_z", &python_query_z)
-        .def("get_zone_and_area", &get_zone_and_area)
-        .def("find_random_point_around_circle", &find_random_point_around_circle)
-        .def("adt_loaded", &adt_loaded)
-        .def("unload_adt", &unload_adt)
-        .def("line_of_sight", &los);
+        .def(py::init<const std::string&, const std::string&>(),
+            py::arg("data_path"),
+            py::arg("map_name")
+        )
+        .def("load_all_adts",
+            &pathfind::Map::LoadAllADTs,
+            R"del(Loads all ADTs for the map in order for pathfinding to be immediately available everywhere on the map.
+
+This may take a while depending on the map size.)del"
+        )
+        .def("load_adt_at",
+            &load_adt_at,
+            "Load ADT at specific map coordinate.",
+            py::arg("x"),
+            py::arg("y")
+        )
+        .def("load_adt",
+            &load_adt,
+            "Load specific ADT.",
+            py::arg("adt_x"),
+            py::arg("adt_y")
+        )
+        .def(
+            "find_path",
+           &python_find_path,
+           R"del(Attempts to find a path between `start` and `stop`.
+
+Returns a list of points if a path was found, otherwise an empty list.)del",
+           py::arg("start_x"),
+           py::arg("start_y"),
+           py::arg("start_z"),
+           py::arg("stop_x"),
+           py::arg("stop_y"),
+           py::arg("stop_z")
+        )
+        .def("query_heights",
+            &python_query_heights,
+            "Finds all Z values for a given `x`, `y` coordinate.",
+            py::arg("x"),
+            py::arg("y")
+        )
+        .def("query_z",
+            &python_query_z,
+            R"del(Returns the `stop_z` value for a given `start_x`, `start_y`, `start_z` and `stop_x`, `stop_y`.
+
+This is the value that would be achieved by walking from start to stop.)del",
+            py::arg("start_x"),
+            py::arg("start_y"),
+            py::arg("start_z"),
+            py::arg("stop_x"),
+            py::arg("stop_y")
+        )
+        .def("get_zone_and_area",
+            &get_zone_and_area,
+            "Returns the zone and area values for a specific coordinate.",
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("z")
+        )
+        .def("find_random_point_around_circle",
+            &find_random_point_around_circle,
+            "Returns a random point from a circle within or slightly outside of the given radius.",
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("z"),
+            py::arg("radius")
+        )
+        .def("adt_loaded",
+            &adt_loaded,
+            "Checks if a specific ADT is loaded.",
+            py::arg("adt_x"),
+            py::arg("adt_y")
+        )
+        .def("unload_adt",
+            &unload_adt,
+            "Unloads a specific ADT.",
+            py::arg("adt_x"),
+            py::arg("adt_y")
+        )
+        .def("line_of_sight",
+            &los,
+            R"del(Checks for line of sight from `start` to `stop`.
+
+If `doodads` is `False` doodads will not be considered during calculations.)del",
+            py::arg("start_x"),
+            py::arg("start_y"),
+            py::arg("start_z"),
+            py::arg("stop_x"),
+            py::arg("stop_y"),
+            py::arg("stop_z"),
+            py::arg("doodads")
+        );
 }


### PR DESCRIPTION
By default `pybind11` just calls the arguments `arg0`, `arg1`, etc., which is less than ideal. This should make it significantly nicer to use the Python API with an IDE.

This PR also unifies the path handling across the exe, python and C.

`create_directories` does nothing if the directory already exists, so there's no need to check.

Fixes #64.