### PR TITLE
Fix alpha parsing.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,7 +44,7 @@ jobs:
         submodules: true
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.15
+      uses: pypa/cibuildwheel@v2.16.5
       env:
         MACOSX_DEPLOYMENT_TARGET: "10.15"
 

--- a/pathfind/Map.cpp
+++ b/pathfind/Map.cpp
@@ -407,6 +407,18 @@ std::shared_ptr<WmoModel> Map::EnsureWmoModelLoaded(const std::string& mpq_path)
     return model;
 }
 
+bool Map::HasADTs() const
+{
+    for (int y = 0; y < MeshSettings::Adts; ++y)
+        for (int x = 0; x < MeshSettings::Adts; ++x) {
+            if (m_hasADT[x][y]) {
+                return true;
+            }
+        }
+
+    return false;
+}
+
 bool Map::HasADT(int x, int y) const
 {
     return m_hasADT[x][y];
@@ -716,6 +728,50 @@ bool Map::FindNextZ(const Tile* tile, float x, float y, float zHint,
 
     if (adtError < rayError)
         result = adtHeight;
+
+    return true;
+}
+
+bool Map::FindPointInBetweenVectors(const math::Vertex& start, const math::Vertex& end, 
+                                    const float distance,
+                                    math::Vertex& inBetweenPoint) const
+{
+    const float generalDistance = math::Vector3::GetDistance(start, end);
+    if (generalDistance < distance) {
+        return false;
+    }
+
+    const float factor = distance / generalDistance;
+    const float dx = start.X + factor * (end.X - start.X);
+    const float dy = start.Y + factor * (end.Y - start.Y);
+    constexpr float extents[] = {1.f, 1.f, 1.f};
+
+    const math::Vertex v1 {dx, dy, start.Z};
+    const math::Vertex v2 {dx, dy, end.Z};
+
+
+    float recastMiddle[3];
+    math::Convert::VertexToRecast(v1, recastMiddle);
+
+    dtPolyRef polyRef;
+    if (m_navQuery.findNearestPoly(recastMiddle, extents, &m_queryFilter,
+                                   &polyRef, nullptr) != DT_SUCCESS)
+    {
+        math::Convert::VertexToRecast(v2, recastMiddle);
+        if (m_navQuery.findNearestPoly(recastMiddle, extents, &m_queryFilter,
+                                       &polyRef, nullptr) != DT_SUCCESS)
+        {
+            return false;
+        }
+    }
+
+    float outputPoint[3];
+    if (m_navQuery.closestPointOnPoly(polyRef, recastMiddle, outputPoint, NULL) !=
+        DT_SUCCESS) {
+        return false;
+    }
+
+    math::Convert::VertexToWow(outputPoint, inBetweenPoint);
 
     return true;
 }

--- a/pathfind/Map.cpp
+++ b/pathfind/Map.cpp
@@ -749,18 +749,15 @@ bool Map::FindPointInBetweenVectors(const math::Vertex& start, const math::Verte
     const math::Vertex v1 {dx, dy, start.Z};
     const math::Vertex v2 {dx, dy, end.Z};
 
-
     float recastMiddle[3];
     math::Convert::VertexToRecast(v1, recastMiddle);
 
     dtPolyRef polyRef;
     if (m_navQuery.findNearestPoly(recastMiddle, extents, &m_queryFilter,
-                                   &polyRef, nullptr) != DT_SUCCESS)
-    {
+                                   &polyRef, nullptr) != DT_SUCCESS) {
         math::Convert::VertexToRecast(v2, recastMiddle);
         if (m_navQuery.findNearestPoly(recastMiddle, extents, &m_queryFilter,
-                                       &polyRef, nullptr) != DT_SUCCESS)
-        {
+                                       &polyRef, nullptr) != DT_SUCCESS) {
             return false;
         }
     }
@@ -772,7 +769,6 @@ bool Map::FindPointInBetweenVectors(const math::Vertex& start, const math::Verte
     }
 
     math::Convert::VertexToWow(outputPoint, inBetweenPoint);
-
     return true;
 }
 

--- a/pathfind/Map.cpp
+++ b/pathfind/Map.cpp
@@ -736,7 +736,7 @@ bool Map::FindPointInBetweenVectors(const math::Vertex& start, const math::Verte
                                     const float distance,
                                     math::Vertex& inBetweenPoint) const
 {
-    const float generalDistance = math::Vector3::GetDistance(start, end);
+    const float generalDistance = start.GetDistance(end);
     if (generalDistance < distance) {
         return false;
     }

--- a/pathfind/Map.hpp
+++ b/pathfind/Map.hpp
@@ -110,6 +110,7 @@ public:
     Map(const std::filesystem::path& dataPath, const std::string& mapName);
 
     bool HasADT(int x, int y) const;
+    bool HasADTs() const;
     bool IsADTLoaded(int x, int y) const;
     bool LoadADT(int x, int y);
     void UnloadADT(int x, int y);
@@ -158,6 +159,11 @@ public:
     bool FindRandomPointAroundCircle(const math::Vertex& centerPosition,
                                      float radius,
                                      math::Vertex& randomPoint) const;
+
+    bool FindPointInBetweenVectors(const math::Vertex& start,
+                                   const math::Vertex& end,
+                                   const float distance,
+                                   math::Vertex& inBetweenPoint) const;
 
     const dtNavMesh& GetNavMesh() const { return m_navMesh; }
     const dtNavMeshQuery& GetNavMeshQuery() const { return m_navQuery; }

--- a/pathfind/python.cpp
+++ b/pathfind/python.cpp
@@ -66,6 +66,10 @@ bool adt_loaded(pathfind::Map& map, int adt_x, int adt_y) {
     return map.IsADTLoaded(adt_x, adt_y);
 }
 
+bool has_adts(pathfind::Map& map) {
+    return map.HasADTs();
+}
+
 py::list python_query_heights(const pathfind::Map& map, float x, float y)
 {
     py::list result;
@@ -104,6 +108,18 @@ py::object get_zone_and_area(pathfind::Map& map, float x, float y, float z)
     if (!map.ZoneAndArea(p, zone, area))
         return py::none();
     return py::make_tuple(zone, area);
+}
+
+py::object find_point_in_between_vectors(pathfind::Map& map, float distance, float x1, float y1, float z1, float x2, float y2, float z2)
+{
+    const math::Vertex start {x1, y1, z1};
+    const math::Vertex end {x2, y2, z2};
+    math::Vertex in_between_point {};
+    if (!map.FindPointInBetweenVectors(start, end, distance, in_between_point)) {
+        return py::none();
+    }
+
+    return py::make_tuple(in_between_point.X, in_between_point.Y, in_between_point.Z);
 }
 
 py::object find_random_point_around_circle(pathfind::Map& map, float x, float y, float z, float radius) {
@@ -181,6 +197,17 @@ This is the value that would be achieved by walking from start to stop.)del",
             py::arg("y"),
             py::arg("z")
         )
+        .def("find_point_in_between_vectors",
+            &find_point_in_between_vectors,
+            "Returns a point in between two vectors given a distance.",
+            py::arg("distance"),
+            py::arg("x1"),
+            py::arg("y1"),
+            py::arg("z1"),
+            py::arg("x2"),
+            py::arg("y2"),
+            py::arg("z2")
+        )
         .def("find_random_point_around_circle",
             &find_random_point_around_circle,
             "Returns a random point from a circle within or slightly outside of the given radius.",
@@ -188,6 +215,10 @@ This is the value that would be achieved by walking from start to stop.)del",
             py::arg("y"),
             py::arg("z"),
             py::arg("radius")
+        )
+        .def("has_adts",
+            &has_adts,
+            "Checks if the map has any ADT."
         )
         .def("adt_loaded",
             &adt_loaded,

--- a/utility/BinaryStream.cpp
+++ b/utility/BinaryStream.cpp
@@ -193,6 +193,12 @@ bool BinaryStream::GetChunkLocation(const std::string& chunkName,
     return false;
 }
 
+bool BinaryStream::IsEOF()
+{
+    auto const buff = buffer();
+    return m_rpos == buff->size();
+}
+
 void BinaryStream::Compress()
 {
     std::vector<std::uint8_t> buff(

--- a/utility/BinaryStream.hpp
+++ b/utility/BinaryStream.hpp
@@ -102,6 +102,7 @@ public:
     bool GetChunkLocation(const std::string& chunkName, size_t& result) const;
     bool GetChunkLocation(const std::string& chunkName, size_t startLoc,
                           size_t& result) const;
+    bool IsEOF();
 
     void Compress();
     void Decompress();

--- a/utility/Vector.cpp
+++ b/utility/Vector.cpp
@@ -17,10 +17,10 @@ Vector3 Vector3::CrossProduct(const Vector3& a, const Vector3& b)
                    a.X * b.Y - a.Y * b.X);
 }
 
-float Vector3::GetDistance(const Vector3& a, const Vector3& b)
+float Vector3::GetDistance(const Vector3& other) const
 {
-    return sqrtf(powf((a.X - b.X), 2) + powf((a.Y - b.Y), 2) +
-                 powf((a.Z - b.Z), 2));
+    return sqrtf(powf((X - other.X), 2) + powf((Y - other.Y), 2) +
+                 powf((Z - other.Z), 2));
 }
 
 Vector3 Vector3::Normalize(const Vector3& a)

--- a/utility/Vector.cpp
+++ b/utility/Vector.cpp
@@ -17,7 +17,7 @@ Vector3 Vector3::CrossProduct(const Vector3& a, const Vector3& b)
                    a.X * b.Y - a.Y * b.X);
 }
 
-float GetDistance(const Vector3& a, const Vector3& b)
+float Vector3::GetDistance(const Vector3& a, const Vector3& b)
 {
     return sqrtf(powf((a.X - b.X), 2) + powf((a.Y - b.Y), 2) +
                  powf((a.Z - b.Z), 2));

--- a/utility/Vector.cpp
+++ b/utility/Vector.cpp
@@ -17,6 +17,12 @@ Vector3 Vector3::CrossProduct(const Vector3& a, const Vector3& b)
                    a.X * b.Y - a.Y * b.X);
 }
 
+float GetDistance(const Vector3& a, const Vector3& b)
+{
+    return sqrtf(powf((a.X - b.X), 2) + powf((a.Y - b.Y), 2) +
+                 powf((a.Z - b.Z), 2));
+}
+
 Vector3 Vector3::Normalize(const Vector3& a)
 {
     const float d = 1.f / sqrt(a.X * a.X + a.Y * a.Y + a.Z * a.Z);

--- a/utility/Vector.hpp
+++ b/utility/Vector.hpp
@@ -25,7 +25,7 @@ struct Vector3
     static Vector3 CrossProduct(const Vector3& a, const Vector3& b);
     static Vector3 Normalize(const Vector3& a);
     static Vector3 Transform(const Vector3& position, const Matrix& matrix);
-    static float GetDistance(const Vector3& a, const Vector3& b);
+    float GetDistance(const Vector3& other) const;
 
     float X;
     float Y;

--- a/utility/Vector.hpp
+++ b/utility/Vector.hpp
@@ -28,7 +28,7 @@ struct Vector3
     static Vector3 Transform(const Vector3& position, const Matrix& matrix);
     static float GetDistance(const Vector3& a, const Vector3& b)
     {
-        return std::sqrt(pow((a.X - b.X), 2) + std::pow((a.Y - b.Y), 2) + std::pow((a.Z - b.Z), 2));
+        return ::sqrt(pow((a.X - b.X), 2) + ::pow((a.Y - b.Y), 2) + ::pow((a.Z - b.Z), 2));
     }
 
     float X;

--- a/utility/Vector.hpp
+++ b/utility/Vector.hpp
@@ -25,6 +25,12 @@ struct Vector3
     static Vector3 CrossProduct(const Vector3& a, const Vector3& b);
     static Vector3 Normalize(const Vector3& a);
     static Vector3 Transform(const Vector3& position, const Matrix& matrix);
+    static float GetDistance(const Vector3& a, const Vector3& b)
+    {
+        return std::sqrt(std::pow((a.X - b.X), 2) +
+                         std::pow((a.Y - b.Y), 2) +
+                         std::pow((a.Z - b.Z), 2));
+    }
 
     float X;
     float Y;

--- a/utility/Vector.hpp
+++ b/utility/Vector.hpp
@@ -27,9 +27,7 @@ struct Vector3
     static Vector3 Transform(const Vector3& position, const Matrix& matrix);
     static float GetDistance(const Vector3& a, const Vector3& b)
     {
-        return std::sqrt(std::pow((a.X - b.X), 2) +
-                         std::pow((a.Y - b.Y), 2) +
-                         std::pow((a.Z - b.Z), 2));
+        return sqrt(pow((a.X - b.X), 2) + pow((a.Y - b.Y), 2) + pow((a.Z - b.Z), 2));
     }
 
     float X;

--- a/utility/Vector.hpp
+++ b/utility/Vector.hpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <iostream>
-#include <cmath>
 
 #ifndef PI
 #    define PI 3.14159264f
@@ -26,10 +25,7 @@ struct Vector3
     static Vector3 CrossProduct(const Vector3& a, const Vector3& b);
     static Vector3 Normalize(const Vector3& a);
     static Vector3 Transform(const Vector3& position, const Matrix& matrix);
-    static float GetDistance(const Vector3& a, const Vector3& b)
-    {
-        return ::sqrt(pow((a.X - b.X), 2) + ::pow((a.Y - b.Y), 2) + ::pow((a.Z - b.Z), 2));
-    }
+    static float GetDistance(const Vector3& a, const Vector3& b);
 
     float X;
     float Y;

--- a/utility/Vector.hpp
+++ b/utility/Vector.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <cmath>
 
 #ifndef PI
 #    define PI 3.14159264f
@@ -27,7 +28,7 @@ struct Vector3
     static Vector3 Transform(const Vector3& position, const Matrix& matrix);
     static float GetDistance(const Vector3& a, const Vector3& b)
     {
-        return sqrt(pow((a.X - b.X), 2) + pow((a.Y - b.Y), 2) + pow((a.Z - b.Z), 2));
+        return std::sqrt(pow((a.X - b.X), 2) + std::pow((a.Y - b.Y), 2) + std::pow((a.Z - b.Z), 2));
     }
 
     float X;


### PR DESCRIPTION
- Python bindings: HasADTs, FindPointInBetweenVectors.
- Fixes parsing for the following alpha maps:

1. Blackfathom
2. Collin
3. GnomeragonInstance
4. Monastery
5. RazorfenDowns
6. StormwindJail
7. StormwindPrison
8. Uldaman
9. WailingCaverns
10. UnderMine (No data)